### PR TITLE
Tentatively allow for the market to include items in adjacent inventories

### DIFF
--- a/src/main/java/net/ndrei/villagermarket/VillagerMarketContainer.java
+++ b/src/main/java/net/ndrei/villagermarket/VillagerMarketContainer.java
@@ -114,10 +114,13 @@ public class VillagerMarketContainer extends Container {
     }
 
     public MerchantRecipeInfo[] getRecipes(String villagerTypeFilter) {
+
+
         if (player.world.isRemote) {
             List<MerchantRecipeInfo> temp = merchantRecipes;
             if (villagerTypeFilter != null && !villagerTypeFilter.isEmpty()) {
-                temp = merchantRecipes.stream().filter((recipe) -> !recipe.getVillager().getDisplayName().getFormattedText().equals(villagerTypeFilter)).collect(Collectors.toList());
+                String filter = villagerTypeFilter.replace(((Character) (char) 167).toString() + "r", "");
+                temp = merchantRecipes.stream().filter((recipe) -> recipe != null && recipe.villager_type.equals(filter)).collect(Collectors.toList());
             }
             return temp.toArray(new MerchantRecipeInfo[0]);
         }
@@ -247,6 +250,7 @@ public class VillagerMarketContainer extends Container {
         public final MerchantRecipe recipe;
         public final int recipeIndex;
         public final int times;
+        public final String villager_type;
 
         public MerchantRecipeInfo (NBTTagCompound tag, VillagerMarketContainer container) {
             this.villager = null;
@@ -254,6 +258,7 @@ public class VillagerMarketContainer extends Container {
             this.villagerId = tag.getInteger("id");
             this.recipeIndex = tag.getInteger("recipeIndex");
             this.times = tag.getInteger("times");
+            this.villager_type = tag.getString("villager_name");
             this.recipe = new MerchantRecipe(tag.getCompoundTag("recipe"));
         }
 
@@ -264,6 +269,7 @@ public class VillagerMarketContainer extends Container {
             this.recipeIndex = recipeIndex;
             this.times = times;
             this.container = container;
+            this.villager_type = villager.getDisplayName().getUnformattedComponentText().replace("entity.Village", "");
         }
 
         public NBTTagCompound getAsNBT () {
@@ -272,6 +278,7 @@ public class VillagerMarketContainer extends Container {
             result.setInteger("recipeIndex", recipeIndex);
             result.setInteger("times", times);
             result.setTag("recipe", recipe.writeToTags());
+            result.setString("villager_name", villager.getDisplayName().getUnformattedComponentText().replace("entity.Villager.", ""));
             return result;
         }
 

--- a/src/main/java/net/ndrei/villagermarket/VillagerMarketGuiHandler.java
+++ b/src/main/java/net/ndrei/villagermarket/VillagerMarketGuiHandler.java
@@ -34,7 +34,7 @@ public class VillagerMarketGuiHandler implements IGuiHandler {
         BlockPos pos = new BlockPos(x, y, z);
         IBlockState state = world.getBlockState(pos);
         if (state.getBlock() == VillagerMarketMod.villagerMarket) {
-            return new VillagerMarketScreen(new VillagerMarketContainer(player));
+            return new VillagerMarketScreen(new VillagerMarketContainer(player, pos));
         }
 
         return null;

--- a/src/main/java/net/ndrei/villagermarket/VillagerMarketMod.java
+++ b/src/main/java/net/ndrei/villagermarket/VillagerMarketMod.java
@@ -2,6 +2,8 @@ package net.ndrei.villagermarket;
 
 import java.util.List;
 import com.google.common.collect.Lists;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.IItemHandlerModifiable;
 import org.apache.logging.log4j.Logger;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -51,14 +53,6 @@ public class VillagerMarketMod {
         MinecraftForge.EVENT_BUS.register(new VillagerMarketEvents());
         VillagerMarketMod.villagerMarket = new VillagerMarketBlock();
 
-//        VillagerMarketMod.villagerMarket = new VillagerMarketBlock();
-//        VillagerMarketMod.villagerMarket.register();
-//        VillagerMarketMod.villagerMarket.setCreativeTab(VillagerMarketMod.creativeTab);
-//
-//        if (event.getSide() == Side.CLIENT) {
-//            VillagerMarketMod.villagerMarket.registerRenderer();
-//        }
-
         NetworkRegistry.INSTANCE.registerGuiHandler(VillagerMarketMod.instance, new VillagerMarketGuiHandler());
 
         this.networkWrapper = new SimpleNetworkWrapper("VM|GUI");
@@ -66,9 +60,9 @@ public class VillagerMarketMod {
         this.networkWrapper.registerMessage(VillagerMarketNetwork.ServerHandler.class, VillagerMarketPacketServer.class, 1, Side.SERVER);
     }
 
-    static List<ItemStack> getCombinedInventory(IInventory inventory) {
+    static List<ItemStack> getCombinedInventory(IItemHandler inventory) {
         List<ItemStack> list = Lists.newArrayList();
-        for (int i = 0; i < inventory.getSizeInventory(); i++) {
+        for (int i = 0; i < inventory.getSlots(); i++) {
             ItemStack stack = inventory.getStackInSlot(i);
             if (stack.isEmpty()) {
                 continue;
@@ -90,13 +84,13 @@ public class VillagerMarketMod {
         return list;
     }
 
-    static int extractFromCombinedInventory(IInventory inventory, ItemStack stack, int amount) {
+    static int extractFromCombinedInventory(IItemHandler inventory, ItemStack stack, int amount) {
         if (stack.isEmpty()) {
             return 0;
         }
 
         int taken = 0;
-        for (int i = 0; i < inventory.getSizeInventory(); i++) {
+        for (int i = 0; i < inventory.getSlots(); i++) {
             ItemStack temp = inventory.getStackInSlot(i);
             if (temp.isEmpty() || (temp.getItem() != stack.getItem())) {
                 continue;
@@ -104,9 +98,9 @@ public class VillagerMarketMod {
 
             ItemStack takenStack;
             if (temp.getCount() == amount) {
-                takenStack = inventory.removeStackFromSlot(i);
+                takenStack = inventory.extractItem(i, amount, false);
             } else {
-                takenStack = inventory.decrStackSize(i, Math.min(amount, temp.getCount()));
+                takenStack = inventory.extractItem(i, Math.min(amount, temp.getCount()), false);
             }
 
             taken += takenStack.getCount();


### PR DESCRIPTION
This is unfortunately quite a large refactoring.

1) As default vanilla chest inventories are not accessible to the client via item capability/TileEntity (the contents are only synced via EntityPlayerMP::sendAllContents), the logic for determining how many of a trade you could make had to be moved to the server side.
2) This resulted in an overhaul of the packets sent from the server to the client to include the max number of times a trade can be made (for UI purposes) instead of calculating it on the client. 

I've been testing it quite extensively on my server both with and without an attached inventory (for the past 2 weeks) and it appears to function a) identical to how it did previously, but b) now with the ability to place items in a chest or inventory next to it, and have those included when interacting.

The results of trades are, obviously, still placed in your own inventory.

Review/feedback etc much appreciated. I've also taken the liberty of fixing some of the package-private methods to public/private where relevant.